### PR TITLE
add future parser to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,28 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.4
 env:
-  - PUPPET_GEM_VERSION="2.7.14"
   - PUPPET_GEM_VERSION="~> 2.7"
   - PUPPET_GEM_VERSION="~> 3.3"
+  - PUPPET_GEM_VERSION="~> 3.7" FUTURE_PARSER="yes"
 matrix:
   allow_failures:
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 3.7" FUTURE_PARSER="yes"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 3.7" FUTURE_PARSER="yes"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.7" FUTURE_PARSER="yes"
+    - rvm: 2.1.4
+      env: PUPPET_GEM_VERSION="~> 3.7" FUTURE_PARSER="yes"
     - rvm: ruby-head
   exclude:
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="2.7.14"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="2.7.14"
-    - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 2.7"
     - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 2.7"
+    - rvm: 2.1.4
       env: PUPPET_GEM_VERSION="~> 2.7"
   fast_finish: true
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,15 @@ gem 'rake',                    :require => false
 gem 'puppetlabs_spec_helper',  :require => false
 gem 'puppet-lint',             :require => false
 gem 'puppet-syntax',           :require => false
-gem 'rspec-puppet-augeas',     :require => false
+gem 'rspec-puppet',            :require => false
+# rspec 3 spews warnings with rspec-puppet 1.0.1
+gem 'rspec-core', '~> 2.0',    :require => false
+
+# rspec-puppet > 1 appears to breaks rspec-puppet-augeas 0.2.3
+# see https://github.com/domcleal/rspec-puppet-augeas/issues/9
+# rspec-puppet-augeas requires rspec-puppet < 1
+gem 'rspec-puppet-augeas', '0.3.0',    :require => false
 gem 'ruby-augeas',             :require => false
-# fixing rspec-puppet to < 1.0 due to these issues:
-# https://github.com/domcleal/rspec-puppet-augeas/issues/9
-# https://github.com/domcleal/rspec-puppet-augeas/issues/14
-gem 'rspec-puppet', '< 1.0',   :require => false
 gem 'beaker',                  :require => false
 gem 'beaker-rspec',            :require => false
 gem 'serverspec',              :require => false


### PR DESCRIPTION
Allow future parser to fail because of rspec-puppet-augeas & rspec-puppet > 1
compat issues.
